### PR TITLE
allow requests with empty request data and headers

### DIFF
--- a/lib/k6-helper.js
+++ b/lib/k6-helper.js
@@ -52,6 +52,9 @@ module.exports = {
     if (data) {
       result += util.format(",\n      \"%s\"", data);
     }
+    else if (headers.length && data == null && method.toLowerCase() != "get") {
+      result += ",\n      null";
+    }
 
     // request headers
     if (headers.length) {


### PR DESCRIPTION
Allow requests with empty request data and at least one param (for example, request headers). 

For example, the post method has 3 parameters: url, [body], [params], without this patch, the generated code for the indicated case (empty body and headers) will have only 2 parameters as result, the body parameter will not appear and the params will be treated as the body value by mistake.

A post request with empty request data and no params/headers is generated correctly because body and params parameters are optional. Same happens with other methods (del, patch, put.. etc), the get method is the exception (https://docs.k6.io/docs/get-url-body-params).

The headers.length appears to avoid http.post(url, null) request call, the http.post(url) one is valid and better.