### PR TITLE
allow variables in the request protocol

### DIFF
--- a/lib/generate/Request.js
+++ b/lib/generate/Request.js
@@ -37,7 +37,12 @@ function Request (name, request, result, block) {
 function address (address, feature) {
   feature.address = new URI(address.toString())
   if (!feature.address.protocol()) {
-    feature.address.protocol('http')
+    if (address.protocol) {
+      // do not use setter 'protocol()' as it will reject variables like {{protocol}}
+      feature.address.protocol = address.protocol
+    } else {
+      feature.address.protocol('http')
+    }
   }
 }
 


### PR DESCRIPTION
this allows variables e.g. {{protocol}} to be used in the request address, making switching between http and https in different environments easier for example, fixes #27