### PR TITLE
Improve OAuth1 support

### DIFF
--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -20,6 +20,18 @@ program
   .option('-e, --environment <path>', 'JSON export of environment.')
   .option('-c, --csv <path>', 'CSV data file. Used to fill data variables.')
   .option('-j, --json <path>', 'JSON data file. Used to fill data variables.')
+  .option('--oauth1-consumer-key <value>', 'OAuth1 consumer key.')
+  .option('--oauth1-consumer-secret <value>', 'OAuth1 consumer secret.')
+  .option('--oauth1-access-token <value>', 'OAuth1 access token.')
+  .option('--oauth1-token-secret <value>', 'OAuth1 token secret.')
+  .option(
+    '--oauth1-signature-method <value>',
+    'OAuth1 signature method. One of HMAC-SHA1 HMAC-SHA256 PLAINTEXT.'
+  )
+  .option('--oauth1-timestamp <value>', 'OAuth1 timestamp.')
+  .option('--oauth1-nonce <value>', 'OAuth1 nonce.')
+  .option('--oauth1-version <value>', 'OAuth1 version.')
+  .option('--oauth1-realm <value>', 'OAuth1 realm.')
   .action(run)
   .parse(process.argv)
 
@@ -34,14 +46,7 @@ async function run (...args) {
   // Convert
   let result
   try {
-    result = await convertFile(input, {
-      globals: options.global,
-      environment: options.environment,
-      csv: !!options.csv,
-      json: !!options.json,
-      iterations: options.iterations,
-      id: true
-    })
+    result = await convertFile(input, translateOptions(options))
   } catch (e) {
     console.error(e.message)
     console.log(e)
@@ -68,5 +73,31 @@ async function run (...args) {
     })
   } else {
     console.log(result)
+  }
+}
+
+function translateOptions (options) {
+  return {
+    globals: options.global,
+    environment: options.environment,
+    csv: !!options.csv,
+    json: !!options.json,
+    iterations: options.iterations,
+    id: true,
+    oauth1: translateOauth1Options(options)
+  }
+}
+
+function translateOauth1Options (options) {
+  return {
+    consumerKey: options.oauth1ConsumerKey,
+    consumerSecret: options.oauth1ConsumerSecret,
+    accessToken: options.oauth1AccessToken,
+    tokenSecret: options.oauth1TokenSecret,
+    signatureMethod: options.oauth1SignatureMethod,
+    timestamp: options.oauth1Timestamp,
+    nonce: options.oauth1Nonce,
+    version: options.oauth1Version,
+    realm: options.oauth1Realm
   }
 }

--- a/lib/auth/oauth1.js
+++ b/lib/auth/oauth1.js
@@ -1,4 +1,5 @@
 const util = require('../util')
+const { InvalidError } = require('../error')
 
 const Location = Object.freeze({
   Address: 0,
@@ -9,6 +10,7 @@ const Location = Object.freeze({
 class Oauth1Auth {
   constructor (settings, feature) {
     const params = settings.parameters()
+    validate(params)
     this.imports = new Map()
       .set('OAuth', './libs/oauth-1.0a.js')
       .set('hmac', { base: 'k6/crypto' })
@@ -156,6 +158,24 @@ function renderHashFunction (method, options) {
       break
     default:
       throw new Error(`Unrecognized OAuth 1.0 signature method: ${method}`)
+  }
+}
+
+function validate (params) {
+  if (!(
+    params.has('signatureMethod') &&
+    params.has('consumerKey') &&
+    params.has('consumerSecret') &&
+    params.has('token') &&
+    params.has('tokenSecret')
+  )) {
+    throw new InvalidError(
+      { name: 'InvalidOAuth1' },
+      'To convert this collection provide OAuth credentials. ' +
+      'Either include them in the collection or use the --oauth1-* CLI ' +
+      'options. Minimum required configuration is signature method, ' +
+      'consumer key, consumer secret, access token, and token secret.'
+    )
   }
 }
 

--- a/lib/convert/file.js
+++ b/lib/convert/file.js
@@ -2,33 +2,31 @@ const { ReadError } = require('../error')
 const convertJson = require('./json')
 const fs = require('fs')
 
-async function convertFile (path, {
-  globals,
-  environment,
-  csv,
-  json,
-  iterations,
-  id
-} = {}) {
+async function convertFile (path, options = {}) {
   let text
-  const options = { csv, json, iterations, id }
   try {
     text = fs.readFileSync(path, { encoding: 'utf8' })
   } catch (e) {
     throw new ReadError(e, `Could not read input file: ${path}`)
   }
-  if (globals) {
+  if (options.globals) {
     try {
-      options.globals = fs.readFileSync(globals, { encoding: 'utf8' })
+      options.globals = fs.readFileSync(options.globals, { encoding: 'utf8' })
     } catch (e) {
-      throw new ReadError(e, `Could not read globals file: ${globals}`)
+      throw new ReadError(e, `Could not read globals file: ${options.globals}`)
     }
   }
-  if (environment) {
+  if (options.environment) {
     try {
-      options.environment = fs.readFileSync(environment, { encoding: 'utf8' })
+      options.environment = fs.readFileSync(
+        options.environment,
+        { encoding: 'utf8' }
+      )
     } catch (e) {
-      throw new ReadError(e, `Could not read environment file: ${environment}`)
+      throw new ReadError(
+        e,
+        `Could not read environment file: ${options.environment}`
+      )
     }
   }
   return convertJson(text, options)

--- a/lib/convert/json.js
+++ b/lib/convert/json.js
@@ -2,31 +2,23 @@ const { ParseError } = require('../error')
 const convertObject = require('./object')
 const stripJsonComments = require('strip-json-comments')
 
-async function convertJson (collectionJson, {
-  globals,
-  environment,
-  csv,
-  json,
-  iterations,
-  id
-} = {}) {
+async function convertJson (collectionJson, options = {}) {
   let collection
-  const options = { csv, json, iterations, id }
   try {
     collection = JSON.parse(stripJsonComments(collectionJson))
   } catch (e) {
     throw new ParseError(e, 'Failed to parse collection JSON')
   }
-  if (globals) {
+  if (options.globals) {
     try {
-      options.globals = JSON.parse(stripJsonComments(globals))
+      options.globals = JSON.parse(stripJsonComments(options.globals))
     } catch (e) {
       throw new ParseError(e, 'Failed to parse globals JSON')
     }
   }
-  if (environment) {
+  if (options.environment) {
     try {
-      options.environment = JSON.parse(stripJsonComments(environment))
+      options.environment = JSON.parse(stripJsonComments(options.environment))
     } catch (e) {
       throw new ParseError(e, 'Failed to parse environment JSON')
     }

--- a/lib/convert/object.js
+++ b/lib/convert/object.js
@@ -7,39 +7,32 @@ const render = require('../render')
 const transformer = require('postman-collection-transformer')
 const util = require('../util')
 
-async function convertObject (collection, {
-  globals,
-  environment,
-  csv,
-  json,
-  iterations,
-  id
-} = {}) {
+async function convertObject (collection, options = {}) {
   const version = detectVersion(collection)
   if (version[0] === '1') {
     collection = await upgrade(collection)
   }
   const node = new postman.Collection(collection)
   const result = util.makeResult()
-  result.setting.id = id
-  if (iterations) {
-    result.iterations = iterations
+  result.setting.id = options.id
+  if (options.iterations) {
+    result.iterations = options.iterations
   }
-  if (csv) {
+  if (options.csv) {
     result.data.path = `./data.csv`
-  } else if (json) {
+  } else if (options.json) {
     result.data.path = `./data.json`
   }
-  result.data.type = (csv ? 'csv' : json ? 'json' : null)
+  result.data.type = (options.csv ? 'csv' : options.json ? 'json' : null)
   if (result.data.type === 'csv') {
     result.imports.set('papaparse', './libs/papaparse.js')
   }
   Collection(node, result)
-  if (globals) {
-    Globals(globals, result)
+  if (options.globals) {
+    Globals(options.globals, result)
   }
-  if (environment) {
-    Environment(environment, result)
+  if (options.environment) {
+    Environment(options.environment, result)
   }
   return render(result)
 }

--- a/lib/convert/object.js
+++ b/lib/convert/object.js
@@ -15,6 +15,9 @@ async function convertObject (collection, options = {}) {
   const node = new postman.Collection(collection)
   const result = util.makeResult()
   result.setting.id = options.id
+  if (options.oauth1) {
+    result.setting.oauth1 = options.oauth1
+  }
   if (options.iterations) {
     result.iterations = options.iterations
   }

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,11 +1,13 @@
 const { VError } = require('verror')
 
 class PostmanToK6Error extends VError {}
+class InvalidError extends PostmanToK6Error {}
 class ParseError extends PostmanToK6Error {}
 class ReadError extends PostmanToK6Error {}
 
 module.exports = {
   PostmanToK6Error,
+  InvalidError,
   ParseError,
   ReadError
 }

--- a/lib/generate/Request.js
+++ b/lib/generate/Request.js
@@ -103,6 +103,7 @@ function authentication (direct, feature, result, block) {
     authInvalid(settings, feature)
     return
   }
+  supersedeAuth(settings, result)
   const auth = new Auth[settings.type](settings, feature)
   applyAuth(auth, feature, result, block)
 }
@@ -113,6 +114,42 @@ function selectAuth (auths) {
     }
   }
   return null
+}
+function supersedeAuth (settings, result) {
+  if (settings.type === 'oauth1') {
+    supersedeAuthOauth1(settings, result)
+  }
+}
+function supersedeAuthOauth1 (settings, result) {
+  const options = result.setting.oauth1
+  const params = settings.parameters()
+  if (options.consumerKey) {
+    params.upsert({ key: 'consumerKey', value: options.consumerKey })
+  }
+  if (options.consumerSecret) {
+    params.upsert({ key: 'consumerSecret', value: options.consumerSecret })
+  }
+  if (options.accessToken) {
+    params.upsert({ key: 'token', value: options.accessToken })
+  }
+  if (options.tokenSecret) {
+    params.upsert({ key: 'tokenSecret', value: options.tokenSecret })
+  }
+  if (options.signatureMethod) {
+    params.upsert({ key: 'signatureMethod', value: options.signatureMethod })
+  }
+  if (options.timestamp) {
+    params.upsert({ key: 'timestamp', value: options.timestamp })
+  }
+  if (options.nonce) {
+    params.upsert({ key: 'nonce', value: options.nonce })
+  }
+  if (options.version) {
+    params.upsert({ key: 'version', value: options.version })
+  }
+  if (options.realm) {
+    params.upsert({ key: 'realm', value: options.realm })
+  }
 }
 function applyAuth (auth, feature, result, block) {
   if (auth.imports) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,7 +59,8 @@ function makeGroup ({
 function makeResult () {
   return {
     setting: {
-      id: false
+      id: false,
+      oauth1: {}
     },
     options: {},
     iterations: null,


### PR DESCRIPTION
Raises a descriptive error if insufficient OAuth1 configuration is available. I'm not finding a clear description of which config is required. Went for the set that's nearest I could tell:

>To convert this collection provide OAuth credentials. Either include them in the collection or use the --oauth1-* CLI options. Minimum required configuration is signature method, consumer key, consumer secret, access token, and token secret.

Adds command line options for specifying OAuth1 configuration. CLI options override settings in the collection.

```shell
  --oauth1-consumer-key <value>      OAuth1 consumer key.
  --oauth1-consumer-secret <value>   OAuth1 consumer secret.
  --oauth1-access-token <value>      OAuth1 access token.
  --oauth1-token-secret <value>      OAuth1 token secret.
  --oauth1-signature-method <value>  OAuth1 signature method. One of HMAC-SHA1 HMAC-SHA256 PLAINTEXT.
  --oauth1-timestamp <value>         OAuth1 timestamp.
  --oauth1-nonce <value>             OAuth1 nonce.
  --oauth1-version <value>           OAuth1 version.
  --oauth1-realm <value>             OAuth1 realm.

```

This command converts the `twitter.json` example:

```shell
node bin/postman-to-k6.js example/v2/twitter.json --oauth1-signature-method HMAC-SHA256 --oauth1-consumer-key ConsumerKey --oauth1-consumer-secret ConsumerSecret --oauth1-access-token AccessToken --oauth1-token-secret TokenSecret
```

Closes #20.