### PR TITLE
Support empty query in AWS request

### DIFF
--- a/lib/auth/awsv4.js
+++ b/lib/auth/awsv4.js
@@ -54,7 +54,7 @@ ${aid.indent(credential.join(`,\n`))}
     lines.push(`const signed = aws4.sign(options, credential);`)
 
     // Request
-    lines.push(`const [path, query] = signed.path.split("?");
+    lines.push(`const [path, query = ""] = signed.path.split("?");
 config.address = new URI()
   .protocol(address.protocol())
   .hostname(signed.hostname)

--- a/test/int/auth.js
+++ b/test/int/auth.js
@@ -183,7 +183,7 @@ export default function() {
         sessionToken: "session"
       };
       const signed = aws4.sign(options, credential);
-      const [path, query] = signed.path.split("?");
+      const [path, query = ""] = signed.path.split("?");
       config.address = new URI()
         .protocol(address.protocol())
         .hostname(signed.hostname)


### PR DESCRIPTION
Adds support for an empty query string in an AWS request.

Current logic of the `awsv4` auth type fails if the request URL has an empty query string. The query becomes `undefined` and nulls out some later values. Tweaks the logic to correctly handle an empty query.

Closes #46.