### PR TITLE
Exclude disabled headers when converting requests

### DIFF
--- a/lib/generate/Request/analyze.js
+++ b/lib/generate/Request/analyze.js
@@ -118,8 +118,10 @@ function dataGraphQL(body, feature) {
 }
 
 function headers(headers, feature, result) {
-  headers.each(({ key, value }) => {
-    header(key, value, feature, result);
+  headers.each(({ key, value, disabled }) => {
+    if (!disabled) {
+      header(key, value, feature, result);
+    }
   });
 }
 


### PR DESCRIPTION
Exclude disabled headers when converting requests

fixes #102

Please let me know if this naive approach is sufficient or if you require any changes.