### PR TITLE
pr-support-postman-variables-query

### DIFF
--- a/lib/generate/Request/analyze.js
+++ b/lib/generate/Request/analyze.js
@@ -65,7 +65,7 @@ function address(address, feature, result) {
     // Scheme missing
     feature.address = new URI(`http://${addressText}`);
   }
-  feature.address = feature.address.query(URI.encodeReserved(feature.address.query()));
+  feature.address = feature.address.query(feature.address.query().replace(/\s/g, '%20'));
 }
 
 function data(request, feature, result) {

--- a/test/int/format.js
+++ b/test/int/format.js
@@ -200,7 +200,7 @@ export default function() {
   postman[Request]({
     name: "Test Request 1",
     method: "GET",
-    address: "http://1.example.com/?search=kittens",
+    address: "http://1.example.com/?search=kittens&postId={{postId}}",
     headers: {
       Session: "abc123"
     },

--- a/test/int/format.js
+++ b/test/int/format.js
@@ -200,7 +200,8 @@ export default function() {
   postman[Request]({
     name: "Test Request 1",
     method: "GET",
-    address: "http://1.example.com/?search=kittens&postId={{postId}}",
+    address:
+      "http://1.example.com/?search=kittens&postId={{postId}}&orderby=lastAction%20asc",
     headers: {
       Session: "abc123"
     },

--- a/test/material/2.1/format-v2.1.json
+++ b/test/material/2.1/format-v2.1.json
@@ -188,6 +188,10 @@
                         {
                             "key": "postId",
                             "value": "{{postId}}"
+						},
+                        {
+                            "key": "orderby",
+                            "value": "lastAction asc"
                         }
 					]
 				}

--- a/test/material/2.1/format-v2.1.json
+++ b/test/material/2.1/format-v2.1.json
@@ -184,7 +184,11 @@
 						{
 							"key": "search",
 							"value": "kittens"
-						}
+						},
+                        {
+                            "key": "postId",
+                            "value": "{{postId}}"
+                        }
 					]
 				}
 			},


### PR DESCRIPTION
Fix for unwanted encoding of Postman variables in query string, but keep support for "space".

In https://github.com/k6io/postman-to-k6/pull/93, we introduced `URI.encodeReserved(feature.address.query())` to leverage encoding of query string to handle spaces/+ properly.

The `[URI.encodeReserved()](http://medialize.github.io/URI.js/docs.html#static-encodeReserved)` handles the special properties, but also encode the {{}} syntax for Postman variables, which is not desired.

In this PR, I made the proposal to remove URI.encodeReserved() but still keep the support of "space" encoding.

In attachment you can find the correct result for a postman collection with 2 query string with {{}}, + and space.