### PR TITLE
Added option to use a JSON file to pass all CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,17 @@ All the available CLI options can be used in the config file. By passing the CLI
 $ postman-to-k6 collection.json --cli-options-file cli-config.json
 ```
 
+Example of JSON CLI config file
+
+```json
+{
+  "output": "k6-script.js",
+  "k6-params": "config/k6-params.json",
+  "environment": "config/envs/team.env.json",
+  "separate": true
+}
+```
+
 ## Docker Usage
 
 Using the Docker image, you execute the tool as follows:

--- a/README.md
+++ b/README.md
@@ -213,6 +213,21 @@ Skips any post-request scripts during conversion
 $ postman-to-k6 collection.json --skip-pre -o k6-script.js
 ```
 
+### CLI options file
+
+Manage all the CLI options in a separate configuration file and pass them along to the postman-to-k6 command.
+To make the CLI usage easier, especially in CI/CD implementations.
+
+All the available CLI options can be used in the config file. By passing the CLI options as parameters, you can overwrite the defined CLI options defined in the file.
+
+| Flag | Verbose              | Default |
+| ---- | -------------------- | ------- |
+|      | `--cli-options-file` | false   |
+
+```shell
+$ postman-to-k6 collection.json --cli-options-file cli-config.json
+```
+
 ## Docker Usage
 
 Using the Docker image, you execute the tool as follows:

--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -19,9 +19,10 @@ program
   .option('-i, --iterations <count>', 'Number of iterations.')
   .option('-g, --global <path>', 'JSON export of global variables.')
   .option('-e, --environment <path>', 'JSON export of environment.')
+  .option('--cli-options-file <path>', 'postman-to-k6 CLI options file. Useful for CI/CD integrations.')
   .option('-c, --csv <path>', 'CSV data file. Used to fill data variables.')
   .option('-j, --json <path>', 'JSON data file. Used to fill data variables.')
-  .option('--k6-params <path>', 'K6 param options config file. Used to set the K6 params used during HTTP requests.')
+  .option('--k6-params <path>', 'K6 param options config file. Sets K6 params used during HTTP requests.')
   .option('--skip-pre', 'Skips pre-request scripts')
   .option('--skip-post', 'Skips post-request scripts')
   .option('--oauth1-consumer-key <value>', 'OAuth1 consumer key.')
@@ -45,8 +46,25 @@ async function run(...args) {
     console.error('Provide path to Postman collection');
     return;
   }
-  const options = args.pop();
+  let options = args.pop();
   const input = args.shift();
+
+  let cliOptions = {};
+  if (options.cliOptionsFile) {
+    try {
+      const cliOptionsFilePath = path.resolve(options.cliOptionsFile);
+      cliOptions = JSON.parse(await fs.readFile(cliOptionsFilePath, 'utf8'));
+    } catch (err) {
+      console.error(
+        '\x1b[31m',
+        `postman-to-k6 CLI options error - no such file or directory "${options.cliOptionsFile}"`
+      );
+      process.exit(1);
+    }
+  }
+
+  // Merge CLI configuration file with CLI parameters
+  options = Object.assign({}, cliOptions, options);
 
   // Convert
   let main, requests;

--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const convertFile = require('../lib/convert/file');
+const utils = require('../lib/convert/utils');
 const fs = require('fs-extra');
 const outputRequests = require('./requests');
 const path = require('path');
@@ -54,6 +55,7 @@ async function run(...args) {
     try {
       const cliOptionsFilePath = path.resolve(options.cliOptionsFile);
       cliOptions = JSON.parse(await fs.readFile(cliOptionsFilePath, 'utf8'));
+      cliOptions = utils.keysToCamel(cliOptions);
     } catch (err) {
       console.error(
         '\x1b[31m',

--- a/lib/convert/utils.js
+++ b/lib/convert/utils.js
@@ -1,0 +1,41 @@
+function isArray(a) {
+  return Array.isArray(a);
+}
+
+function isObject(o) {
+  return o === Object(o) && !isArray(o) && typeof o !== 'function';
+}
+
+function keysToCamel(o) {
+  if (isObject(o)) {
+    const n = {};
+
+    Object.keys(o).forEach(k => {
+      n[toCamel(k)] = keysToCamel(o[k]);
+    });
+
+    return n;
+  } else if (isArray(o)) {
+    return o.map(i => {
+      return keysToCamel(i);
+    });
+  }
+
+  return o;
+}
+
+function toCamel(s) {
+  return s.replace(/([-_][a-z])/gi, $1 => {
+    return $1
+      .toUpperCase()
+      .replace('-', '')
+      .replace('_', '');
+  });
+}
+
+Object.assign(exports, {
+  keysToCamel,
+  isArray,
+  isObject,
+  toCamel,
+});

--- a/package.json
+++ b/package.json
@@ -80,11 +80,5 @@
         "test-hoc": "cross-env NODE_PATH=lib:test ava",
         "test-int": "cross-env NODE_PATH=lib:test ava test/int",
         "test-unit": "cross-env NODE_PATH=lib:test ava test/unit"
-    },
-    "husky": {
-        "hooks": {
-            "pre-commit": "yarn lint && yarn test",
-            "pre-push": "yarn test"
-        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -80,5 +80,11 @@
         "test-hoc": "cross-env NODE_PATH=lib:test ava",
         "test-int": "cross-env NODE_PATH=lib:test ava test/int",
         "test-unit": "cross-env NODE_PATH=lib:test ava test/unit"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "yarn lint && yarn test",
+            "pre-push": "yarn test"
+        }
     }
 }


### PR DESCRIPTION
If you want to use this new enhancement, I have provided a forked NPM package version that contains the feature:

Replace in your packages.json:
```
"dependencies": {
    "postman-to-k6": "^1.5.0"
  }
```
to
```
"dependencies": {
    "@apideck/postman-to-k6": "^1.8.1"
  }
```

This is a forked NPM package, to provide this new feature. The current maintainers are quite overloaded by the acquisition of K6 by Grafana. By forking the repo & package, users can keep using new PR's & (security) fixes. At a later stage the changes can potentially be merged back in the original postman-to-k6 repo.

The [changelog](https://github.com/apideck-libraries/postman-to-k6/blob/main/CHANGELOG.md) contains the differences between the original package & the forked version.