### PR TITLE
Added the option to generate K6 Request tags

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "ecmaVersion": 8
   },
   "rules": {
-    "semi": "error",
+    "semi": [2, "always"],
     "space-before-function-paren": ["error", "never"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -172,6 +172,26 @@ Pass [K6 parameter options](https://k6.io/docs/javascript-api/k6-http/params) as
 ```shell
 $ postman-to-k6 collection.json --k6-params k6-params.json -o k6-script.js
 ```
+### K6 Request tag
+
+Generate [K6 request name tags](https://k6.io/docs/using-k6/http-requests/#http-request-tags) based on available naming strategies:
+- none: no automatic generated tags | default
+- `request`: uses the request name as tag (example "Show all accounts")
+- `folder-request`: uses Postman folder name and the request name (example: "Accounts - Show all accounts")
+
+| Flag | Verbose             | Default |
+| ---- | ------------------- | ------- |
+|      | `--request-tagging` | N/A     |
+
+Example for `request` strategy
+```shell
+$ postman-to-k6 collection.json --request-tagging=request -o k6-script.js
+```
+
+Example for `folder-request` strategy
+```shell
+$ postman-to-k6 collection.json --request-tagging=folder-request -o k6-script.js
+```
 
 ### Separate
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Converts a [Postman collection](https://www.getpostman.com/docs/collections) to 
   - [Global Variables](#global-variables)
   - [CSV Data File](#csv-data-file)
   - [JSON Data File](#json-data-file)
+  - [K6 Param Options File](#k6-param-options-file)
+  - [K6 Request tag](#k6-request-tag)
   - [Separate](#separate)
 - [Docker Usage](#docker-usage)
 - [Examples](#examples)
@@ -179,18 +181,18 @@ Generate [K6 request name tags](https://k6.io/docs/using-k6/http-requests/#http-
 - `request`: uses the request name as tag (example "Show all accounts")
 - `folder-request`: uses Postman folder name and the request name (example: "Accounts - Show all accounts")
 
-| Flag | Verbose             | Default |
-| ---- | ------------------- | ------- |
-|      | `--request-tagging` | N/A     |
+| Flag | Verbose                | Default |
+| ---- | ---------------------- | ------- |
+|      | `--k6-request-tagging` | N/A     |
 
 Example for `request` strategy
 ```shell
-$ postman-to-k6 collection.json --request-tagging=request -o k6-script.js
+$ postman-to-k6 collection.json --k6-request-tagging=request -o k6-script.js
 ```
 
 Example for `folder-request` strategy
 ```shell
-$ postman-to-k6 collection.json --request-tagging=folder-request -o k6-script.js
+$ postman-to-k6 collection.json --k6-request-tagging=folder-request -o k6-script.js
 ```
 
 ### Separate
@@ -206,7 +208,7 @@ $ postman-to-k6 collection.json --separate -o k6-script.js
 ```
 
 ```shell
-postman-to-k6 collection.json -s -o k6-script.js
+$ postman-to-k6 collection.json -s -o k6-script.js
 ```
 
 ### Skip Pre
@@ -276,8 +278,7 @@ $ postman-to-k6 example/v2/echo.json -o k6-script.js
   - `pm.response.headers`
 - The Hawk authentication method.
 - Deprecated `xmlToJson` method.
-- Request IDs are changed. Postman doesn't provide them in the export so we
-  have to generate new ones.
+- Request IDs are changed. Postman doesn't provide them in the export, so we have to generate new ones.
 
 ## Other similar tools
 

--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -21,10 +21,10 @@ program
   .option('-e, --environment <path>', 'JSON export of environment.')
   .option('-c, --csv <path>', 'CSV data file. Used to fill data variables.')
   .option('-j, --json <path>', 'JSON data file. Used to fill data variables.')
-  .option('--k6-params <path>', 'K6 param options config file. Used to set the K6 params used during HTTP requests.')
+  .option('--k6-params <path>', 'K6 param options config file. Sets K6 params used during HTTP requests.')
+  .option('--k6-request-tagging <value>', 'Apply K6 tags to the requests for reporting.')
   .option('--skip-pre', 'Skips pre-request scripts')
   .option('--skip-post', 'Skips post-request scripts')
-  .option('--request-tagging <value>', 'Apply K6 tags to the requests for reporting.')
   .option('--oauth1-consumer-key <value>', 'OAuth1 consumer key.')
   .option('--oauth1-consumer-secret <value>', 'OAuth1 consumer secret.')
   .option('--oauth1-access-token <value>', 'OAuth1 access token.')
@@ -97,11 +97,11 @@ function translateOptions(options) {
     csv: !!options.csv,
     json: !!options.json,
     k6Params: options.k6Params,
+    k6RequestTagging: options.k6RequestTagging,
     iterations: options.iterations,
     id: true,
     oauth1: translateOauth1Options(options),
     separate: !!options.separate,
-    requestTagging: options.requestTagging,
     skip: {
       pre: options.skipPre,
       post: options.skipPost,

--- a/bin/postman-to-k6.js
+++ b/bin/postman-to-k6.js
@@ -24,6 +24,7 @@ program
   .option('--k6-params <path>', 'K6 param options config file. Used to set the K6 params used during HTTP requests.')
   .option('--skip-pre', 'Skips pre-request scripts')
   .option('--skip-post', 'Skips post-request scripts')
+  .option('--request-tagging <value>', 'Apply K6 tags to the requests for reporting.')
   .option('--oauth1-consumer-key <value>', 'OAuth1 consumer key.')
   .option('--oauth1-consumer-secret <value>', 'OAuth1 consumer secret.')
   .option('--oauth1-access-token <value>', 'OAuth1 access token.')
@@ -100,6 +101,7 @@ function translateOptions(options) {
     id: true,
     oauth1: translateOauth1Options(options),
     separate: !!options.separate,
+    requestTagging: options.requestTagging,
     skip: {
       pre: options.skipPre,
       post: options.skipPost,

--- a/lib/aid.js
+++ b/lib/aid.js
@@ -84,7 +84,9 @@ function makeResult() {
     post: null,
     auths: [],
     main: [],
+    group: { name: null },
     requestNames: {},
+    requestTagging: null,
     requests: {},
   };
 }

--- a/lib/convert/object.js
+++ b/lib/convert/object.js
@@ -22,7 +22,9 @@ async function convertObject(collection, options = {}) {
   if (options.oauth1) {
     result.setting.oauth1 = options.oauth1;
   }
-
+  if (options.requestTagging) {
+    result.setting.requestTagging = options.requestTagging;
+  }
   result.setting.separate = options.separate;
   if (options.iterations) {
     result.iterations = options.iterations;
@@ -66,6 +68,7 @@ const upgradeOptions = {
   outputVersion: '2.1.0',
   retainIds: true,
 };
+
 function upgrade(collection) {
   return new Promise((resolve, reject) => {
     transformer.convert(collection, upgradeOptions, (error, result) => {

--- a/lib/convert/object.js
+++ b/lib/convert/object.js
@@ -22,8 +22,8 @@ async function convertObject(collection, options = {}) {
   if (options.oauth1) {
     result.setting.oauth1 = options.oauth1;
   }
-  if (options.requestTagging) {
-    result.setting.requestTagging = options.requestTagging;
+  if (options.k6RequestTagging) {
+    result.setting.requestTagging = options.k6RequestTagging;
   }
   result.setting.separate = options.separate;
   if (options.iterations) {

--- a/lib/generate/ItemGroup.js
+++ b/lib/generate/ItemGroup.js
@@ -12,6 +12,7 @@ function ItemGroup(group, result, block) {
   block.main.push(spec);
   const members = aid.spread(group.items);
   for (const member of members) {
+    result.group = { name: group.name };
     ListMember(member, result, spec);
   }
 }

--- a/lib/generate/Request/config.js
+++ b/lib/generate/Request/config.js
@@ -1,7 +1,7 @@
 const aid = require('../../aid');
 const { BodyItemType } = require('../../enum');
 
-function renderConfig(name, id, feature) {
+function renderConfig(name, id, feature, result) {
   const items = [];
   items.push(`name: ${JSON.stringify(name)}`);
   if (id) items.push(`id: ${JSON.stringify(id)}`);
@@ -19,6 +19,11 @@ function renderConfig(name, id, feature) {
   if (options) {
     items.push(`options: ${options}`);
   }
+  const requestTag = renderRequestTag(name, feature, result);
+  if (requestTag) {
+    items.push(`tags: { name: ${JSON.stringify(requestTag)} }`);
+  }
+
   renderLogic(items, feature);
   return `{
 ${aid.indent(items.join(',\n'))}
@@ -193,6 +198,26 @@ ${aid.indent(auth)}
   } else {
     return null;
   }
+}
+
+function renderRequestTag(name, feature, result) {
+  let tagName;
+  // Request tagging strategy: folder-request
+  if (
+    result.setting.requestTagging &&
+    result.setting.requestTagging === 'folder-request'
+  ) {
+    tagName = `${result.group.name} - ${name}`;
+  }
+  // Request tagging strategy: request
+  if (
+    result.setting.requestTagging &&
+    result.setting.requestTagging === 'request'
+  ) {
+    tagName = name;
+  }
+
+  return tagName;
 }
 
 module.exports = renderConfig;

--- a/lib/generate/Request/inline.js
+++ b/lib/generate/Request/inline.js
@@ -4,7 +4,7 @@ const renderConfig = require('./config');
 
 function inline(name, request, result, block) {
   const feature = analyze(request, result, block);
-  const config = renderConfig(name, id(result), feature);
+  const config = renderConfig(name, id(result), feature, result);
   block.main.push(`postman[Request](${config})`);
 }
 

--- a/lib/generate/separate/aggregate.js
+++ b/lib/generate/separate/aggregate.js
@@ -10,6 +10,7 @@ function makeTree(name = null, auth = null) {
     name,
     auth,
     locations: [],
+    group: { name: null },
     items: []
   };
 }
@@ -39,6 +40,7 @@ function ListMember(member, tree) {
 
 function ItemGroup(group, tree) {
   const result = makeTree(group.name || group.id, group.auth);
+  result.group.name = group.name;
   const list = aid.spread(group.items);
   List(list, result);
   tree.locations.push(result);

--- a/lib/generate/separate/index.js
+++ b/lib/generate/separate/index.js
@@ -5,7 +5,7 @@ const render = require('./render');
 function separate(node, result) {
   const aggregated = aggregate(node);
   const mapped = map(aggregated);
-  result.requests = render(mapped);
+  result.requests = render(mapped, result);
 }
 
 module.exports = separate;

--- a/lib/generate/separate/map/index.js
+++ b/lib/generate/separate/map/index.js
@@ -12,18 +12,21 @@ function map(aggregated) {
 
 function content(spec, container) {
   const generators = {};
-  items(spec.items, container, generators);
+  items(spec.items, container, generators, spec.group);
   locations(spec.locations, container, generators);
 }
 
-function items(list, container, generators) {
+function items(list, container, generators, group) {
   for (const spec of list) {
-    item(spec, container, generators);
+    item(spec, container, generators, group);
   }
 }
 
-function item(spec, container, generators) {
+function item(spec, container, generators, group) {
   const designation = designate(spec.name, container, generators, '.js');
+  if (group) {
+    spec.group = group;
+  }
   container[designation] = spec;
 }
 

--- a/lib/generate/separate/render.js
+++ b/lib/generate/separate/render.js
@@ -5,42 +5,49 @@ const postman = require('postman-collection');
 const prettier = require('prettier');
 const { Auth } = require('./sym');
 
-function render(mapped) {
-  return location(mapped);
+function render(mapped, result) {
+  return location(mapped, 1, null, result);
 }
 
-function location(node, depth = 1, upstreamAuth = null) {
+function location(node, depth = 1, upstreamAuth = null, result) {
   const auth = node[Auth] || upstreamAuth;
   const tree = {};
-  entries(node, tree, depth, auth);
+  entries(node, tree, depth, auth, result);
   return tree;
 }
 
-function entries(node, tree, depth, auth) {
+function entries(node, tree, depth, auth, result) {
   for (const name of Object.keys(node)) {
     const spec = node[name];
-    tree[name] = entry(spec, depth, auth);
+    tree[name] = entry(spec, depth, auth, result);
   }
 }
 
-function entry(node, depth, auth) {
+function entry(node, depth, auth, result) {
   if (postman.Item.isItem(node)) {
-    return item(node, depth, auth);
+    return item(node, depth, auth, result);
   } else if (typeof node === 'object') {
-    return location(node, depth + 1, auth);
+    return location(node, depth + 1, auth, result);
   } else {
     throw new Error('Unrecognized node type in file system mapping');
   }
 }
 
-function item(node, depth, auth) {
+function item(node, depth, auth, itemResult) {
   const auths = [];
   if (auth) {
     auths.push(auth);
   }
-  const result = aid.makeResult();
+  const result = Object.assign({}, aid.makeResult());
+  result.setting = itemResult.setting;
   result.setting.id = true;
   result.setting.separate = true;
+  result.group = itemResult.group;
+
+  // Transform group name to item result
+  if (node.group) {
+    result.group = node.group;
+  }
   const block = aid.makeGroup({ auths });
   Item(node, result, block);
   const simplified = simplify(result, block);


### PR DESCRIPTION
If you want to use this new feature, I have provided a forked NPM package version that contains the feature:

Replace in your packages.json:
```
"dependencies": {
    "postman-to-k6": "^1.5.0"
  }
```
to
```
"dependencies": {
    "@apideck/postman-to-k6": "^1.8.1"
  }
```

This is a forked NPM package, to provide this new feature. The current maintainers are quite overloaded by the acquisition of K6 by Grafana. By forking the repo & package, users can keep using new PR's & (security) fixes. At a later stage the changes can potentially be merged back in the original postman-to-k6 repo.

The [changelog](https://github.com/apideck-libraries/postman-to-k6/blob/main/CHANGELOG.md) contains the differences between the original package & the forked version.